### PR TITLE
implement --map option

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -9,7 +9,7 @@ import Bot
 import Data.String (fromString)
 import Data.Text (pack, unpack)
 
-data Cmd = Training Settings (Maybe Int) (Maybe Board)
+data Cmd = Training Settings (Maybe Int) (Maybe BoardId)
          | Arena Settings
          deriving (Show, Eq)
 
@@ -24,7 +24,7 @@ settings = Settings <$> (Key <$> argument (Just . pack) (metavar "key"))
 trainingCmd :: Parser Cmd
 trainingCmd = Training <$> settings
                        <*> optional (option (long "turns"))
-                       <*> pure Nothing
+                       <*> optional (strOption (long "map"))
 
 arenaCmd :: Parser Cmd
 arenaCmd = Arena <$> settings

--- a/src/Vindinium/Api.hs
+++ b/src/Vindinium/Api.hs
@@ -19,7 +19,7 @@ import Control.Monad (liftM, mzero)
 import Control.Monad.IO.Class (liftIO)
 import Control.Applicative ((<$>), (<*>))
 
-startTraining :: Maybe Int -> Maybe Board -> Vindinium State
+startTraining :: Maybe Int -> Maybe BoardId -> Vindinium State
 startTraining mi mb = do
     url <- startUrl "training"
     let obj = object ( maybe [] (\i -> [("turns", toJSON i)]) mi

--- a/src/Vindinium/Play.hs
+++ b/src/Vindinium/Play.hs
@@ -7,7 +7,7 @@ module Vindinium.Play
 import Vindinium.Types
 import Vindinium.Api
 
-playTraining :: Maybe Int -> Maybe Board -> Bot -> Vindinium State
+playTraining :: Maybe Int -> Maybe BoardId -> Bot -> Vindinium State
 playTraining mt mb b = startTraining mt mb >>= playLoop b
 
 playArena :: Bot -> Vindinium State

--- a/src/Vindinium/Types.hs
+++ b/src/Vindinium/Types.hs
@@ -15,6 +15,7 @@ module Vindinium.Types
         , Tile (..)
         , Pos (..)
         , Dir (..)
+        , BoardId
         )
     where
 
@@ -22,6 +23,8 @@ import Data.Text (Text)
 
 import Control.Monad.Reader (MonadReader, ReaderT, runReaderT, asks)
 import Control.Monad.IO.Class (MonadIO)
+
+type BoardId = String
 
 newtype Key = Key Text deriving (Show, Eq)
 


### PR DESCRIPTION
This patch implements the --map option so that you can use the predefined maps m1, m2, etc.
For example:

```
vindinium training {secret} --map m1 ...
```
