### PR TITLE
Fixed ResponseTimeout and FromJSON Pos ordering issues.

### DIFF
--- a/src/Vindinium/Api.hs
+++ b/src/Vindinium/Api.hs
@@ -59,6 +59,7 @@ request url val = do
                     , (hUserAgent,   "vindinium-starter-haskell")
                     ]
                 , requestBody = jsonBody (injectKey val key)
+                , responseTimeout = Nothing
                 }
 
     liftIO $ withManager defaultManagerSettings $ \mgr ->
@@ -147,7 +148,9 @@ instance FromJSON HeroId where
     parseJSON x = HeroId <$> parseJSON x
 
 instance FromJSON Pos where
-    parseJSON (Object o) = Pos <$> o .: "x" <*> o .: "y"
+    {-parseJSON (Object o) = Pos <$> o .: "x" <*> o .: "y"-}
+    {-AA 20140204 These seem to be labelled around the wrong way in the JSON-}
+    parseJSON (Object o) = Pos <$> o .: "y" <*> o .: "x"
     parseJSON _ = mzero
 
 instance FromJSON Board where


### PR DESCRIPTION
The default timeout for responseTimeout is only 5 seconds.  Setting it to Nothing means the response will wait indefinitely.

Also, I noticed that the x and y positions seem to be labelled around the wrong way.
