### PR TITLE
Fixes for version 0.11.0 of optparse-applicative

### DIFF
--- a/src/Main.hs
+++ b/src/Main.hs
@@ -18,12 +18,12 @@ cmdSettings (Training s _ _) = s
 cmdSettings (Arena s) = s
 
 settings :: Parser Settings
-settings = Settings <$> (Key <$> argument (Just . pack) (metavar "KEY"))
+settings = Settings <$> (Key <$> argument (str >>= (return . pack)) (metavar "KEY"))
                     <*> (fromString <$> strOption (long "url" <> value "http://vindinium.org"))
 
 trainingCmd :: Parser Cmd
 trainingCmd = Training <$> settings
-                       <*> optional (option (long "turns"))
+                       <*> optional (option auto (long "turns"))
                        <*> pure Nothing
 
 arenaCmd :: Parser Cmd

--- a/vindinium.cabal
+++ b/vindinium.cabal
@@ -15,7 +15,7 @@ cabal-version:       >=1.10
 executable vindinium
   main-is:          Main.hs
   hs-source-dirs:   src
-  build-depends:    base >=4.6 && <4.7
+  build-depends:    base >=4.6
                   , mtl
                   , transformers
                   , text
@@ -24,4 +24,4 @@ executable vindinium
                   , HTTP
                   , http-types
                   , http-client
-                  , optparse-applicative
+                  , optparse-applicative >= 0.11.0


### PR DESCRIPTION
Type of `argument' and`option' functions have been changed in the
version 0.11.0 and above.
